### PR TITLE
Fix Issue #36 "How do I unhide the tray icon?"

### DIFF
--- a/src/touchpadindicator.py
+++ b/src/touchpadindicator.py
@@ -713,6 +713,9 @@ Default action. If indicator is not running launch it.'))
             device_list.list()
         elif options.change:
             change_status()
+        else:
+            make_visible()
+        exit(0)
     else:
         print(get_information())
         print('Touchpad-Indicator version: %s' % comun.VERSION)


### PR DESCRIPTION
https://github.com/atareao/Touchpad-Indicator/issues/36
Once Icon is hidden the -s option does nothing, no one was calling the make_visible function. Since --help says it is the default option, added an else to call it at the end and an exit. The fix works on my installation of touchpad-indicator 2.2.1-0extras19.04.0